### PR TITLE
Added version check for EasyBuild

### DIFF
--- a/roles/easybuild-install/defaults/main.yml
+++ b/roles/easybuild-install/defaults/main.yml
@@ -15,3 +15,4 @@ easybuild_software_dir: "{{ HPC_ENV_PREFIX }}/software/"
 easybuild_modules_syntax: Lua
 easybuild_lmod_version: "6.1.3"
 easybuild_lua_version: "5.1.4.9"
+easybuild_eb_version: "3.4.0"

--- a/roles/easybuild-install/tasks/main.yml
+++ b/roles/easybuild-install/tasks/main.yml
@@ -157,20 +157,61 @@
     insertafter: EOF
     create: yes
 
+
+#
+# EasyBuild.
+#
+- name: Check if EasyBuild is installed and if yes what version
+  shell: "module load EasyBuild/{{ easybuild_eb_version }} && eb --version"
+  args:
+    executable: /bin/bash
+    warn: no
+  changed_when: false
+  failed_when: false
+  check_mode: no
+  register: eb_installed_version
+- name: Determine if EasyBuild needs to be (re)installed
+  set_fact:
+    eb_install_from_source: true
+  when: 'eb_installed_version|failed or (eb_installed_version.stdout | regex_replace("^.*EasyBuild([0-9\.]+).*$", "\\1") | version_compare(easybuild_eb_version, operator="!="))'
+- name: Report EasyBuild status
+  debug:
+    msg: 'Will install EasyBuild from source as it is either missing or present in a different version. (Detected {{ eb_installed_version.stdout | regex_replace("^.*EasyBuild ([0-9\.]+).*$", "\\1") }} and need {{ easybuild_eb_version }}.)'
+  when: eb_install_from_source|default(false)
 - name: Download EasyBuild bootstrap script
   get_url:
     url: "https://raw.githubusercontent.com/hpcugent/easybuild-framework/develop/easybuild/scripts/bootstrap_eb.py"
     dest: "{{ easybuild_sources_dir }}/e/EasyBuild/bootstrap_eb.py"
     mode: "{{ MODE_0664_HARD }}"
-    #checksum: 'md5:3b9dab8edf5c8e25db8f6e7d33189a4a' We don't care about the version/checksum as the URL above just fetches the latest and greatest.
+  when: eb_install_from_source|default(false)
 
 #
 # Ansible doesn't run task in a login shell, so we have to source the EasyBuild config manually.
-# We might want to create some abstraction for this.
 #
-- name: install easybuild
+
+- name: install latest version of easybuild
   shell: >
          source {{ easybuild_modules_dir }}/modules.bashrc
          && umask 0002
          && python {{ easybuild_sources_dir }}/e/EasyBuild/bootstrap_eb.py {{ HPC_ENV_PREFIX }}
+  when: eb_install_from_source|default(false)
+- name: Check if the stable EasyBuild version is installed
+  shell: "module load EasyBuild/{{ easybuild_eb_version }} && eb --version"
+  args:
+    executable: /bin/bash
+    warn: no
+  changed_when: false
+  failed_when: false
+  check_mode: no
+  register: eb_installed_version
+- name: Determine if the stable EasyBuild version needs to be installed
+  set_fact:
+    eb_install_from_source: true
+  when: 'eb_installed_version|failed or (eb_installed_version.stdout | regex_replace("^.*EasyBuild([0-9\.]+).*$", "\\1") | version_compare(easybuild_eb_version, operator="!="))'
+- name: install stable version of easybuild
+  shell: >
+        source {{ easybuild_modules_dir }}/modules.bashrc
+        eb --software="EasyBuild",{{ easybuild_eb_version }}
+  when: eb_install_from_source|default(false)
+
 


### PR DESCRIPTION
These are the (intended) steps:
1 - Check version for EasyBuild
2 - If it's 3.4.0, do nothing
3 - If not, install the latest version of EasyBuild and check if it's v3.4.0
4 - If yes, do nothing
5 - If not, use the latest version of EasyBuild to install v3.4.0