### PR TITLE
Introduced handler for deployment of Lua+Lmod+EasyBuild and consitent dir layout of pb_remote_env_cache_dir in sync with deployed 'apps' dir.

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -4,14 +4,14 @@
 # Conventions for global environment variables:
 #  A. User UPPERCASE underscore separated names like for shell env vars.
 #
-MODE_2775_HARD: "u=rwx,g=rwxs,o=rx"
-MODE_2770_HARD: "u=rwx,g=rwxs,o="
-MODE_0775_HARD: "u=rwx,g=rwx,o=rx"
-MODE__775_SOFT: "u+rwX,g+rwX,o+rX,o-w"
-MODE_0664_HARD: "u=rw,g=rw,o=r"
+MODE_2775_HARD: 'u=rwx,g=rwxs,o=rx'
+MODE_2770_HARD: 'u=rwx,g=rwxs,o='
+MODE_0775_HARD: 'u=rwx,g=rwx,o=rx'
+MODE__775_SOFT: 'u+rwX,g+rwX,o+rX,o-w'
+MODE_0664_HARD: 'u=rw,g=rw,o=r'
 ROOT: "{{ ansible_env.HOME }}/BBMRI"
-GROUP: "bbmri"
-#DEFAULT_USER: "vagrant"
+GROUP: 'bbmri'
+#DEFAULT_USER: 'vagrant'
 DEFAULT_USER: "{{ ansible_env.USER }}"
 HPC_ENV_PREFIX: "{{ ROOT }}/apps"
 HPC_GROUP_PREFIX: "{{ ROOT }}/groups/{{ GROUP }}"
@@ -21,10 +21,11 @@ HPC_GROUP_PREFIX: "{{ ROOT }}/groups/{{ GROUP }}"
 #     to separate them from variables defined in roles, which are prefixed with the role name.
 #  B. User lowercase underscore separated names.
 #
-pb_ngs_dna_version: "3.3.3-BBMRI"
-pb_ebconfigs_version: "2.8.7-BBMRI"
+pb_ngs_dna_version: '3.4.0'
+pb_ebconfigs_version: '2.8.10-BBMRI'
+pb_ebconfigs_checksum: 'md5:d3fae3886e47e0eee2871b1aeab94f00'
 pb_ebconfigs_prefix: "{{ easybuild_software_dir }}/easyconfigs/easybuild-easyconfigs-{{ pb_ebconfigs_version }}/easybuild/easyconfigs/"
-pb_tmp_lfs: "tmp01"
+pb_tmp_lfs: 'tmp01'
 pb_base: "{{ HPC_GROUP_PREFIX }}/{{ pb_tmp_lfs }}"
-pb_local_sources_dir: '~/Downloads/apps/sources'
-pb_remote_sources_dir: 'https://molgenis26.gcc.rug.nl/downloads/'
+pb_local_env_cache_dir: '~/Downloads/apps/'
+pb_remote_env_cache_dir: 'https://molgenis26.gcc.rug.nl/downloads/apps/'

--- a/host_vars/boxy-dev
+++ b/host_vars/boxy-dev
@@ -15,5 +15,4 @@ ROOT: "/groups/umcg-gcc/tmp03/ansible_test"
 #  B. Use lowercase underscore separated names.
 #
 pb_ngs_dna_version: "3.4.2"
-pb_ebconfigs_version: "2.8.7-EGI"
 pb_tmp_lfs: "tmp01"

--- a/host_vars/leucine-zipper
+++ b/host_vars/leucine-zipper
@@ -16,5 +16,8 @@ GROUP: "umcg-gd"
 #  B. User lowercase underscore separated names.
 #
 pb_ngs_dna_version: "3.4.2"
-pb_ebconfigs_version: "2.8.7-EGI"
+#pb_ebconfigs_version: "2.8.7-EGI"
+#pb_ebconfigs_checksum: 'md5:259b8b100ceecdc434a2ecb2516556f4'
+pb_ebconfigs_version: '2.8.10-BBMRI'
+pb_ebconfigs_checksum: 'md5:d3fae3886e47e0eee2871b1aeab94f00'
 pb_tmp_lfs: "tmp06"

--- a/host_vars/vcluster1
+++ b/host_vars/vcluster1
@@ -17,4 +17,5 @@ GROUP: "slurm"
 #
 pb_ngs_dna_version: "3.4.2-bare"
 pb_ebconfigs_version: "2.8.7-EGI"
+pb_ebconfigs_checksum: 'md5:259b8b100ceecdc434a2ecb2516556f4'
 pb_tmp_lfs: "tmp01"

--- a/host_vars/vcluster2
+++ b/host_vars/vcluster2
@@ -17,4 +17,5 @@ GROUP: "slurm"
 #
 pb_ngs_dna_version: "3.4.2-bare"
 pb_ebconfigs_version: "2.8.7-EGI"
+pb_ebconfigs_checksum: 'md5:259b8b100ceecdc434a2ecb2516556f4'
 pb_tmp_lfs: "tmp01"

--- a/playbook.yml
+++ b/playbook.yml
@@ -5,7 +5,7 @@
   pre_tasks:
     - name: Verify Ansible version meets requirements.
       assert:
-        that: "ansible_version.full | version_compare('2.2', '>=')"
+        that: "ansible_version.full | version_compare('2.4', '>=')"
         msg: 'You must update Ansible to at least 2.2.x to use this playbook.'
   roles:
   - role: easybuild-install

--- a/playbook.yml
+++ b/playbook.yml
@@ -15,6 +15,10 @@
     with_items:
       - "{{ easybuild_software_dir }}/easyconfigs"
       - "{{ easybuild_sources_dir }}/e/easyconfigs"
+      - "{{ easybuild_sources_dir }}/g/GATK"
+      - "{{ easybuild_sources_dir }}/g/GCC"
+      - "{{ easybuild_sources_dir }}/j/Java"
+      - "{{ easybuild_sources_dir }}/n/numactl"
       - "{{ easybuild_modules_dir }}"
       - "{{ pb_ebconfigs_prefix }}"
       - "{{ HPC_ENV_PREFIX }}/data"
@@ -31,51 +35,66 @@
       - "{{ pb_base }}/projects"
       - "{{ pb_base }}/logs"
       - "{{ pb_base }}/tmp"
-  - name: Download reference data
+  - name: Download reference data and sources for software packages, which cannot be downloaded automagically by EB for technical reasons only.
     get_url: url="{{ item.url }}" dest="{{ item.dest }}" checksum="{{ item.checksum }}" mode="{{ MODE_0664_HARD }}"
     with_items:
-      - url: "{{ pb_remote_sources_dir }}/NGS_DNA-resources/dbSNP/dbsnp_137.b37.vcf.idx"
-        dest: "{{ HPC_ENV_PREFIX }}/data/dbSNP/dbsnp_137.b37.vcf.idx"
+      - url: "{{ pb_remote_env_cache_dir }}/data/dbSNP/dbsnp_137.b37.vcf.idx"
+        dest:         "{{ HPC_ENV_PREFIX }}/data/dbSNP/"
         checksum: 'md5:80a7ce491b9ca192bfdab55d6b759e2e'
-      - url: "{{ pb_remote_sources_dir }}/NGS_DNA-resources/dbSNP/dbsnp_137.b37.vcf"
-        dest: "{{ HPC_ENV_PREFIX }}/data/dbSNP/dbsnp_137.b37.vcf"
+      - url: "{{ pb_remote_env_cache_dir }}/data/dbSNP/dbsnp_137.b37.vcf"
+        dest:         "{{ HPC_ENV_PREFIX }}/data/dbSNP/"
         checksum: 'md5:956b9e21634f1315ef41a010faf291b8'
-      - url: "{{ pb_remote_sources_dir }}/NGS_DNA-resources/referenceGenome/human_g1k_v37_phiX.fasta"
-        dest: "{{ HPC_ENV_PREFIX }}/data/1000G/phase1/human_g1k_v37_phiX.fasta"
+      - url: "{{ pb_remote_env_cache_dir }}/data/1000G/phase1/human_g1k_v37_phiX.fasta"
+        dest: "{{ HPC_ENV_PREFIX }}/data/1000G/phase1/"
         checksum: 'md5:a74fde3942bb0816f30b2f6cfe2c0ec5'
-      - url: "{{ pb_remote_sources_dir }}/NGS_DNA-resources/referenceGenome/human_g1k_v37_phiX.dict"
-        dest: "{{ HPC_ENV_PREFIX }}/data/1000G/phase1/human_g1k_v37_phiX.dict"
+      - url: "{{ pb_remote_env_cache_dir }}/data/1000G/phase1/human_g1k_v37_phiX.dict"
+        dest: "{{ HPC_ENV_PREFIX }}/data/1000G/phase1/"
         checksum: 'md5:bbfeb6a82dede252a0fc6dde9485d2d2'
-      - url: "{{ pb_remote_sources_dir }}/NGS_DNA-resources/referenceGenome/human_g1k_v37_phiX.fasta.amb"
-        dest: "{{ HPC_ENV_PREFIX }}/data/1000G/phase1/human_g1k_v37_phiX.fasta.amb"
+      - url: "{{ pb_remote_env_cache_dir }}/data/1000G/phase1/human_g1k_v37_phiX.fasta.amb"
+        dest: "{{ HPC_ENV_PREFIX }}/data/1000G/phase1/"
         checksum: 'md5:7558698df27f62bc0ed971664e8089a4'
-      - url: "{{ pb_remote_sources_dir }}/NGS_DNA-resources/referenceGenome/human_g1k_v37_phiX.fasta.ann"
-        dest: "{{ HPC_ENV_PREFIX }}/data/1000G/phase1/human_g1k_v37_phiX.fasta.ann"
+      - url: "{{ pb_remote_env_cache_dir }}/data/1000G/phase1/human_g1k_v37_phiX.fasta.ann"
+        dest: "{{ HPC_ENV_PREFIX }}/data/1000G/phase1/"
         checksum: 'md5:e858be5e40ee30ba8c0f584395188c0e'
-      - url: "{{ pb_remote_sources_dir }}/NGS_DNA-resources/referenceGenome/human_g1k_v37_phiX.fasta.bwt"
-        dest: "{{ HPC_ENV_PREFIX }}/data/1000G/phase1/human_g1k_v37_phiX.fasta.bwt"
+      - url: "{{ pb_remote_env_cache_dir }}/data/1000G/phase1/human_g1k_v37_phiX.fasta.bwt"
+        dest: "{{ HPC_ENV_PREFIX }}/data/1000G/phase1/"
         checksum: 'md5:c0570831ca6fff13ee6157eeb1813b88'
-      - url: "{{ pb_remote_sources_dir }}/NGS_DNA-resources/referenceGenome/human_g1k_v37_phiX.fasta.fai"
-        dest: "{{ HPC_ENV_PREFIX }}/data/1000G/phase1/human_g1k_v37_phiX.fasta.fai"
+      - url: "{{ pb_remote_env_cache_dir }}/data/1000G/phase1/human_g1k_v37_phiX.fasta.fai"
+        dest: "{{ HPC_ENV_PREFIX }}/data/1000G/phase1/"
         checksum: 'md5:2bc786e8a1f6b71ba75c3368c2e50b19'
-      - url: "{{ pb_remote_sources_dir }}/NGS_DNA-resources/referenceGenome/human_g1k_v37_phiX.fasta.pac"
-        dest: "{{ HPC_ENV_PREFIX }}/data/1000G/phase1/human_g1k_v37_phiX.fasta.pac"
+      - url: "{{ pb_remote_env_cache_dir }}/data/1000G/phase1/human_g1k_v37_phiX.fasta.pac"
+        dest: "{{ HPC_ENV_PREFIX }}/data/1000G/phase1/"
         checksum: 'md5:b42d311e535804ca80aa87f72a52c083'
-      - url: "{{ pb_remote_sources_dir }}/NGS_DNA-resources/referenceGenome/human_g1k_v37_phiX.fasta.sa"
-        dest: "{{ HPC_ENV_PREFIX }}/data/1000G/phase1/human_g1k_v37_phiX.fasta.sa"
+      - url: "{{ pb_remote_env_cache_dir }}/data/1000G/phase1/human_g1k_v37_phiX.fasta.sa"
+        dest: "{{ HPC_ENV_PREFIX }}/data/1000G/phase1/"
         checksum: 'md5:20e20f4d6f884f5bf81d8beafe2eb098'
-      - url: "{{ pb_remote_sources_dir }}/NGS_DNA-resources/snpEff/hg19.tar.gz"
-        dest: "{{ HPC_ENV_PREFIX }}/data/snpEff-4.3/hg19.tar.gz"
+      - url: "{{ pb_remote_env_cache_dir }}/data/snpEff/hg19.tar.gz"
+        dest:         "{{ HPC_ENV_PREFIX }}/data/snpEff-4.3/"
         checksum: 'md5:75db3b74aac7eaa3295d4278443dbb70'
-      - url: "{{ pb_remote_sources_dir }}/NGS_DNA-resources/inSilico.tar.gz"
-        dest: "{{ HPC_ENV_PREFIX }}/data/inSilico/inSilico.tar.gz"
+      - url: "{{ pb_remote_env_cache_dir }}/data/inSilico.tar.gz"
+        dest:         "{{ HPC_ENV_PREFIX }}/data/inSilico/"
         checksum: 'md5:1b7e33b2977786819a2099e3895f623a'
-      - url: "{{ pb_remote_sources_dir }}/NGS_DNA-resources/Agilent.tar.gz"
-        dest: "{{ HPC_ENV_PREFIX }}/data/Agilent/Agilent.tar.gz"
+      - url: "{{ pb_remote_env_cache_dir }}/data/Agilent.tar.gz"
+        dest:         "{{ HPC_ENV_PREFIX }}/data/Agilent/"
         checksum: 'md5:0a76a2dde10ad1899cccc4f32f6ee804'
-      - url: "https://github.com/molgenis/easybuild-easyconfigs/releases/download/{{ pb_ebconfigs_version }}/easybuild-easyconfigs-{{ pb_ebconfigs_version }}-custom.tar.gz"
-        dest: "{{ easybuild_sources_dir }}/e/easyconfigs/{{ pb_ebconfigs_version }}-custom.tar.gz"
-        checksum: 'md5:259b8b100ceecdc434a2ecb2516556f4'
+      - url: "https://github.com/molgenis/easybuild-easyconfigs/releases/download/{{ pb_ebconfigs_version }}/easybuild-easyconfigs-{{ pb_ebconfigs_version }}.tar.gz"
+        dest: "{{ easybuild_sources_dir }}/e/easyconfigs/"
+        checksum: "{{ pb_ebconfigs_checksum }}"
+      - url:  "{{ pb_remote_env_cache_dir }}/sources/g/GCC/gmp-6.0.0a.tar.bz2"
+        dest:           "{{ easybuild_sources_dir }}/g/GCC/"
+        checksum: 'md5:b7ff2d88cae7f8085bd5006096eed470'
+      - url:  "{{ pb_remote_env_cache_dir }}/sources/g/GCC/mpc-1.0.2.tar.gz"
+        dest:           "{{ easybuild_sources_dir }}/g/GCC/"
+        checksum: 'md5:68fadff3358fb3e7976c7a398a0af4c3'
+      - url:  "{{ pb_remote_env_cache_dir }}/sources/g/GCC/gcc-4.9.3.tar.bz2"
+        dest:           "{{ easybuild_sources_dir }}/g/GCC/"
+        checksum: 'md5:6f831b4d251872736e8e9cc09746f327'
+      - url:  "{{ pb_remote_env_cache_dir }}/sources/g/GCC/mpfr-3.1.2.tar.gz"
+        dest:           "{{ easybuild_sources_dir }}/g/GCC/"
+        checksum: 'md5:181aa7bb0e452c409f2788a4a7f38476'
+      - url: "{{ pb_remote_env_cache_dir }}/sources/n/numactl/numactl-2.0.10.tar.gz"
+        dest:          "{{ easybuild_sources_dir }}/n/numactl/"
+        checksum: 'md5:682c38305b2596967881f3d77bc3fc9c'
   - name: Extract downloaded sources and reference data.
     unarchive: src="{{ item.src }}" dest="{{ item.dest }}" remote_src=yes mode="{{ MODE__775_SOFT }}"
     with_items:
@@ -85,33 +104,28 @@
         dest: "{{ HPC_ENV_PREFIX }}/data/"
       - src:  "{{ HPC_ENV_PREFIX }}/data/Agilent/Agilent.tar.gz"
         dest: "{{ HPC_ENV_PREFIX }}/data/Agilent/"
-      - src:  "{{ easybuild_sources_dir }}/e/easyconfigs/{{ pb_ebconfigs_version }}-custom.tar.gz"
+      - src:  "{{ easybuild_sources_dir }}/e/easyconfigs/easybuild-easyconfigs-{{ pb_ebconfigs_version }}.tar.gz"
         dest: "{{ easybuild_software_dir }}/easyconfigs"
-  - name: Copy sources for software packages, which cannot be downloaded automagically by EB for technical or legal reasons.
+  - name: Copy sources for software packages, which cannot be downloaded automagically by EB for technical & legal reasons.
+    # NOTE: This is more or less the same as the download above, but for legal reasons we cannot cache these on publicly accessible server.
+    #       You will have to download these yourself to your local system, so the playbook can copy them to your target systems.
     copy: src="{{ item.src }}" dest="{{ item.dest }}" mode="{{ MODE_0664_HARD }}"
     with_items:
-      - src:   "{{ pb_local_sources_dir }}/g/GCC/gmp-6.0.0a.tar.bz2"
-        dest: "{{ easybuild_sources_dir }}/g/GCC/"
-      - src:   "{{ pb_local_sources_dir }}/g/GCC/mpc-1.0.2.tar.gz"
-        dest: "{{ easybuild_sources_dir }}/g/GCC/"
-      - src:   "{{ pb_local_sources_dir }}/g/GCC/gcc-4.9.3.tar.bz2"
-        dest: "{{ easybuild_sources_dir }}/g/GCC/"
-      - src:   "{{ pb_local_sources_dir }}/g/GCC/mpfr-3.1.2.tar.gz"
-        dest: "{{ easybuild_sources_dir }}/g/GCC/"
-      - src:   "{{ pb_local_sources_dir }}/g/GATK/GenomeAnalysisTK-3.7.tar.bz2"
-        dest: "{{ easybuild_sources_dir }}/g/GATK/"
-      - src:   "{{ pb_local_sources_dir }}/j/Java/jdk-8u45-linux-x64.tar.gz"
-        dest: "{{ easybuild_sources_dir }}/j/Java/"
-      - src:   "{{ pb_local_sources_dir }}/j/Java/jdk-8u74-linux-x64.tar.gz"
-        dest: "{{ easybuild_sources_dir }}/j/Java/"
-      - src:   "{{ pb_local_sources_dir }}/j/Java/jdk-7u80-linux-x64.tar.gz"
-        dest: "{{ easybuild_sources_dir }}/j/Java/"
-      - src:   "{{ pb_local_sources_dir }}/b/bzip2/bzip2-1.0.6.tar.gz"
-        dest: "{{ easybuild_sources_dir }}/b/bzip2/"
-      - src:   "{{ pb_local_sources_dir }}/p/Python/extensions/argparse-1.2.1.tar.gz"
-        dest: "{{ easybuild_sources_dir }}/p/Python/extensions/"
+      - src:  "{{ pb_local_env_cache_dir }}/sources/g/GATK/GenomeAnalysisTK-3.7.tar.bz2"
+        dest:          "{{ easybuild_sources_dir }}/g/GATK/"
+      - src:  "{{ pb_local_env_cache_dir }}/sources/j/Java/jdk-8u45-linux-x64.tar.gz"
+        dest:          "{{ easybuild_sources_dir }}/j/Java/"
+      - src:  "{{ pb_local_env_cache_dir }}/sources/j/Java/jdk-8u74-linux-x64.tar.gz"
+        dest:          "{{ easybuild_sources_dir }}/j/Java/"
+      - src:  "{{ pb_local_env_cache_dir }}/sources/j/Java/jdk-7u80-linux-x64.tar.gz"
+        dest:          "{{ easybuild_sources_dir }}/j/Java/"
+      #- src:  "{{ pb_local_env_cache_dir }}/sources/b/bzip2/bzip2-1.0.6.tar.gz"
+      #  dest:          "{{ easybuild_sources_dir }}/b/bzip2/"
+      #- src:  "{{ pb_local_env_cache_dir }}/sources/p/Python/extensions/argparse-1.2.1.tar.gz"
+      #  dest:          "{{ easybuild_sources_dir }}/p/Python/extensions/"
   - name: Deploy NGS_DNA module with EasyBuild
-    shell: >
-           source {{ easybuild_modules_dir }}/modules.bashrc
-           && module load EasyBuild
-           && eb {{ pb_ebconfigs_prefix }}/n/NGS_DNA/NGS_DNA-{{ pb_ngs_dna_version }}.eb --robot --robot-paths="{{ pb_ebconfigs_prefix }}/:"
+    shell: |
+           source {{ easybuild_modules_dir }}/modules.bashrc \
+           && module load "EasyBuild/{{ easybuild_eb_version }}" \
+           && eb --robot --robot-paths="{{ pb_ebconfigs_prefix }}/:" \
+              {{ pb_ebconfigs_prefix }}/n/NGS_DNA/NGS_DNA-{{ pb_ngs_dna_version }}.eb

--- a/roles/easybuild-install/defaults/main.yml
+++ b/roles/easybuild-install/defaults/main.yml
@@ -12,7 +12,8 @@ HPC_ENV_PREFIX: "/apps/" # default when not overruled by a site specific file in
 easybuild_sources_dir: "{{ HPC_ENV_PREFIX }}/sources/"
 easybuild_modules_dir: "{{ HPC_ENV_PREFIX }}/modules/"
 easybuild_software_dir: "{{ HPC_ENV_PREFIX }}/software/"
-easybuild_modules_syntax: Lua
-easybuild_lmod_version: "6.1.3"
-easybuild_lua_version: "5.1.4.9"
-easybuild_eb_version: "3.4.0"
+easybuild_modules_syntax: 'Lua'
+easybuild_lmod_version: '6.1.3'
+easybuild_lua_version: '5.1.4.9'
+easybuild_eb_version: '3.4.0'
+easybuild_bs_version: '20170808.01'

--- a/roles/easybuild-install/handlers/main.yml
+++ b/roles/easybuild-install/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+  #
+  # Handler to install Lua and Lmod and EasyBuild.
+  # To be triggered when any of these is either not installed or 
+  # when a different version is detected as opposed to the one we want.
+  #
+- name: Install_Lua_Lmod_EasyBuild_trio
+  listen: Install_Lua_Lmod_EasyBuild_trio
+  import_tasks: install_lua_lmod_easybuild.yml

--- a/roles/easybuild-install/tasks/install_lua_lmod_easybuild.yml
+++ b/roles/easybuild-install/tasks/install_lua_lmod_easybuild.yml
@@ -1,0 +1,114 @@
+
+---
+#
+# Lua.
+#
+- name: Download Lua.
+  get_url:
+    url: "http://sourceforge.net/projects/lmod/files/lua-{{ easybuild_lua_version }}.tar.bz2/download"
+    dest: "{{ easybuild_sources_dir }}/l/Lua/lua-{{ easybuild_lua_version }}.tar.bz2"
+    mode: "{{ MODE_0664_HARD }}"
+    checksum: 'md5:a8d0443fe79fc4e9aaded057d81304cd' # 5.1.4.9
+    timeout: 60
+    validate_certs: no # Sourceforge redirects to https and this fails when Python on the target host is version <= 2.6.6.
+- name: Decompress Lua.
+  unarchive:
+    src:  "{{ easybuild_sources_dir }}/l/Lua/lua-{{ easybuild_lua_version }}.tar.bz2"
+    dest: "{{ easybuild_sources_dir }}/l/Lua/"
+    copy: no
+    mode: "{{ MODE__775_SOFT }}"
+- name: Compile and install Lua
+  shell: |
+         cd {{ easybuild_sources_dir }}/l/Lua/lua-{{ easybuild_lua_version }}
+         umask 0002
+         ./configure --with-static=yes \
+                     --prefix={{ easybuild_software_dir }}/Lua/{{ easybuild_lua_version }} \
+             && make install
+
+#
+# Lmod.
+#
+- name: Download Lmod.
+  get_url:
+    url: "https://github.com/TACC/Lmod/archive/{{ easybuild_lmod_version }}.tar.gz"
+    dest: "{{ easybuild_sources_dir }}/l/Lmod/{{ easybuild_lmod_version }}.tar.gz"
+    checksum: 'md5:a2ea3c83f08d4175f08f84ac2a9bd508'
+    mode: "{{ MODE_0664_HARD }}"
+- name: Decompress Lmod.
+  unarchive:
+    src:  "{{ easybuild_sources_dir }}/l/Lmod/{{ easybuild_lmod_version }}.tar.gz"
+    dest: "{{ easybuild_sources_dir }}/l/Lmod/"
+    copy: no
+    mode: "{{ MODE__775_SOFT }}"
+- name: Compile and install Lmod.
+  shell: |
+         export PATH={{ easybuild_software_dir }}/Lua/{{ easybuild_lua_version }}/bin:$PATH
+         cd {{ easybuild_sources_dir }}/l/Lmod/Lmod-{{ easybuild_lmod_version }}
+         umask 0002
+         ./configure --prefix={{ easybuild_software_dir }} \
+                     --with-lua-include={{ easybuild_software_dir }}/Lua/{{ easybuild_lua_version }}/include \
+                     --with-mpathSearch=YES \
+                     --with-caseIndependentSorting=YES \
+             && make install
+
+#
+# EasyBuild.
+#
+- name: Download EasyBuild bootstrap script and deps for offline bootstrapping.
+  get_url: url="{{ item.url }}" dest="{{ item.dest }}" checksum="{{ item.checksum }}" mode="{{ MODE_0664_HARD }}"
+  with_items:
+    - url: 'https://raw.githubusercontent.com/easybuilders/easybuild-framework/ddfa7e0cdff778a1d270efd29a2af02830bcca2b/easybuild/scripts/bootstrap_eb.py'
+      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/bootstrap_eb_{{ easybuild_bs_version }}.py"
+      checksum: 'md5:b970595c701de1ddda0cb8f83448f1f4'
+    - url: 'https://pypi.python.org/packages/82/ec/19d85d2bb91b562195d00db9ac82d7529904e7eabc0597720966bf74714f/vsc-install-0.10.26.tar.gz#md5=c4eb3146d1c56015e43193efb6f65c0f'
+      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/"
+      checksum: 'md5:c4eb3146d1c56015e43193efb6f65c0f'
+    - url: ' https://pypi.python.org/packages/f7/66/1ff7ecc4a93ba37e063f5bfbe395e95a547b1dec73b017c2724f4475a958/vsc-base-2.5.8.tar.gz#md5=57f3f49eab7aa15a96be76e6c89a72d8'
+      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/"
+      checksum: 'md5:57f3f49eab7aa15a96be76e6c89a72d8'
+    - url: 'https://pypi.python.org/packages/f0/23/4edb6a97f8d7712687e851ee0c3fc0b471b6829a0c9b15bb2dd5533c9d05/easybuild-framework-3.4.1.tar.gz#md5=1f10ad23ecdc0098e0ec11322afb1c99'
+      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/"
+      checksum: 'md5:1f10ad23ecdc0098e0ec11322afb1c99'
+    - url: 'https://pypi.python.org/packages/f7/b0/61f52e6f99c71a289352d3e5071300d340306f4a96f0301bc64ee4f5d433/easybuild-easyblocks-3.4.1.tar.gz#md5=cadc9fb4f4a8ebfd541fefb79fafe732'
+      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/"
+      checksum: 'md5:cadc9fb4f4a8ebfd541fefb79fafe732'
+    - url: 'https://pypi.python.org/packages/7f/f7/bbfd15f8c2eab776538c5baa98ad616d519709d6b6b0f47002848069aa33/easybuild-easyconfigs-3.4.1.tar.gz#md5=8bbfaeddfc4c77d41c29730b68b5909b'
+      dest: "{{ easybuild_sources_dir }}/e/EasyBuild/"
+      checksum: 'md5:8bbfaeddfc4c77d41c29730b68b5909b'
+- name: Install latest EasyBuild version with bootstrap script.
+  #
+  # Ansible doesn't run task in a login shell, so we have to source the EasyBuild config manually.
+  #
+  shell: |
+         source ~/.modulesrc
+         umask 0002
+         export EASYBUILD_BOOTSTRAP_SOURCEPATH="{{ easybuild_sources_dir }}/e/EasyBuild/"
+         python {{ easybuild_sources_dir }}/e/EasyBuild/bootstrap_eb_{{ easybuild_bs_version }}.py {{ HPC_ENV_PREFIX }}
+- name: Check if the required EasyBuild version is installed.
+  shell: |
+         source ~/.modulesrc >/dev/null 2>&1
+         module load EasyBuild/{{ easybuild_eb_version }}
+         eb --version 2>&1 | head -1 | sed 's|^This is EasyBuild \([0-9\.]*\).*$|\1|'
+  args:
+    executable: /bin/bash
+    warn: no
+  changed_when: false
+  failed_when: false
+  check_mode: no
+  register: eb_installed_version
+- name: Determine if the required EasyBuild version needs to be installed.
+  set_fact:
+    eb_install_from_source: true
+  when: 'eb_installed_version|failed or (eb_installed_version.stdout | version_compare(easybuild_eb_version, operator="!="))'
+- name: Report EasyBuild status.
+  debug:
+    msg: 'Will install the required EasyBuild version with the latest EasyBuild version as the bootstrapped version is not the requested version. (Detected {{ eb_installed_version.stdout }} and need {{ easybuild_eb_version }}.)'
+  when: eb_install_from_source|default(false)
+- name: Install required EasyBuild version with EasyBuild.
+  shell: |
+         source ~/.modulesrc
+         umask 0002
+         module load EasyBuild
+         eb --software="EasyBuild,{{ easybuild_eb_version }}"
+  when: eb_install_from_source|default(false)
+

--- a/roles/easybuild-install/tasks/main.yml
+++ b/roles/easybuild-install/tasks/main.yml
@@ -20,8 +20,12 @@
       export PATH={{ easybuild_software_dir }}/Lua/{{ easybuild_lua_version }}/bin:$PATH;
       export PATH={{ easybuild_software_dir }}/lmod/lmod/libexec:$PATH
       unset MODULEPATH # Make sure Lmod starts with a clean MODULEPATH
-      source {{ easybuild_software_dir }}/lmod/lmod/init/bash
-      source {{ easybuild_modules_dir }}/modules.bashrc
+      if [ -r {{ easybuild_software_dir }}/lmod/lmod/init/bash ]; then
+        source {{ easybuild_software_dir }}/lmod/lmod/init/bash
+      fi
+      if [ -r {{ easybuild_modules_dir }}/modules.bashrc ]; then
+        source {{ easybuild_modules_dir }}/modules.bashrc
+      fi
     marker: "# {mark} ANSIBLE MANAGED BLOCK - lua lmod modules in path"
     insertafter: EOF
     create: yes
@@ -46,6 +50,7 @@
   # Example output:
   # Lua 5.1.4.7-rtm  Copyright (C) 1994-2008 Lua.org, PUC-Rio
   #
+  #shell: ". ~/.modulesrc >/dev/null 2>&1 && lua -v 2>&1"
   shell: ". ~/.modulesrc && lua -v"
   args:
     executable: /bin/bash
@@ -94,10 +99,12 @@
   # Modules based on Lua: Version 6.5.8  2016-09-03 13:41 -05:00 (CDT)
   #    by Robert McLay mclay@tacc.utexas.edu
   #
-  shell: "unset MODULEPATH && . ~/.modulesrc >/dev/null && lmod -v 2>&1 | grep -i version"
+  shell: "unset MODULEPATH && . ~/.modulesrc >/dev/null 2>&1 && lmod -v 2>&1 | grep -i version"
   args:
     executable: /bin/bash
     warn: no
+  environment:
+    SOURCE_HPC_ENV: "True"   # Required to source our modules.bashrc in non-interactive shells.
   changed_when: false
   failed_when: false
   check_mode: no
@@ -125,8 +132,7 @@
     mode: "{{ MODE__775_SOFT }}"
   when: lmod_install_from_source|default(false)
 - name: Compile and install Lmod
-  shell:
-    cmd: |
+  shell: |
          export PATH={{ easybuild_software_dir }}/Lua/{{ easybuild_lua_version }}/bin:$PATH
          cd {{ easybuild_sources_dir }}/l/Lmod/Lmod-{{ easybuild_lmod_version }}
          ./configure --prefix={{ easybuild_software_dir }} --with-lua-include={{ easybuild_software_dir }}/Lua/{{ easybuild_lua_version }}/include \

--- a/roles/easybuild-install/tasks/main.yml
+++ b/roles/easybuild-install/tasks/main.yml
@@ -1,18 +1,21 @@
 ---
-#
-# This is a brittle way to figure what the version of the latest EasyBuild release is.
-# As we currently don't enforce deployment of a specific version,
-# we might as well forget about the version number here
-# and just install the latest and greatest...
-#
-#- name: Fetch which is the latest release of easybuild
-#  shell: >-
-#    wget https://pypi.python.org/pypi/easybuild -O - |grep title|head -1|awk {'print $2'}
-#  register: easybuild_version
 
-#- name: Debug the easybuildversion
-#  debug: var=easybuild_version
+- name: Create required directories.
+  file: dest="{{item}}" state='directory' mode="{{ MODE_2775_HARD }}"
+  with_items:
+    - "{{ easybuild_sources_dir }}/l/Lmod"
+    - "{{ easybuild_sources_dir }}/l/Lua"
+    - "{{ easybuild_sources_dir }}/e/EasyBuild"
+    - "{{ easybuild_software_dir }}/Lua/{{ easybuild_lua_version }}"
+    - "{{ easybuild_software_dir }}/EasyBuild/"
+    - "{{ easybuild_modules_dir }}/all/EasyBuild"
+    - "{{ easybuild_modules_dir }}/tools/EasyBuild"
+    - "{{ easybuild_modules_dir }}/.lmod"
+    - "{{ HPC_ENV_PREFIX }}/.tmp"
 
+#
+# Update environment.
+#
 - name: Create ~/.modulesrc to make sure our global modules.bashrc with Lmod and EasyBuild environment config will be sourced.
   blockinfile:
     dest: "{{ ansible_env.HOME }}/.modulesrc"
@@ -29,121 +32,6 @@
     marker: "# {mark} ANSIBLE MANAGED BLOCK - lua lmod modules in path"
     insertafter: EOF
     create: yes
-
-- name: Create required directories
-  file: dest="{{item}}" state='directory' mode="{{ MODE_2775_HARD }}"
-  with_items:
-    - "{{ easybuild_sources_dir }}/l/Lmod"
-    - "{{ easybuild_sources_dir }}/l/Lua"
-    - "{{ easybuild_sources_dir }}/e/EasyBuild"
-    - "{{ easybuild_software_dir }}/Lua/{{ easybuild_lua_version }}"
-    - "{{ easybuild_software_dir }}/EasyBuild/"
-    - "{{ easybuild_modules_dir }}/all/EasyBuild"
-    - "{{ easybuild_modules_dir }}/tools/EasyBuild"
-    - "{{ easybuild_modules_dir }}/.lmod"
-
-#
-# Lua.
-#
-- name: Check if Lua is installed and if yes what version
-  #
-  # Example output:
-  # Lua 5.1.4.7-rtm  Copyright (C) 1994-2008 Lua.org, PUC-Rio
-  #
-  #shell: ". ~/.modulesrc >/dev/null 2>&1 && lua -v 2>&1"
-  shell: ". ~/.modulesrc && lua -v"
-  args:
-    executable: /bin/bash
-    warn: no
-  environment:
-    SOURCE_HPC_ENV: "True"   # Required to source our modules.bashrc in non-interactive shells.
-  changed_when: false
-  failed_when: false
-  check_mode: no
-  register: lua_installed_version
-- name: Determine if Lua needs to be (re)installed
-  set_fact:
-    lua_install_from_source: true
-  when: 'lua_installed_version|failed or (lua_installed_version.stderr | regex_replace("^.*Lua ([0-9\.]+).*$", "\\1") | version_compare(easybuild_lua_version, operator="!="))'
-- name: Report Lua status
-  debug:
-    msg: 'Will install Lua from source as it is either missing or present in a different version. (Detected {{ lua_installed_version.stderr | regex_replace("^.*Lua ([0-9\.]+).*$", "\\1") }} and need {{ easybuild_lua_version }}.)'
-  when: lua_install_from_source|default(false)
-- name: Download Lua
-  get_url:
-    url: "http://sourceforge.net/projects/lmod/files/lua-{{ easybuild_lua_version }}.tar.bz2/download"
-    dest: "{{ easybuild_sources_dir }}/l/Lua/lua-{{ easybuild_lua_version }}.tar.bz2"
-    mode: "{{ MODE_0664_HARD }}"
-    checksum: 'md5:a8d0443fe79fc4e9aaded057d81304cd' # 5.1.4.9
-  when: lua_install_from_source|default(false)
-- name: Decompress Lua
-  unarchive:
-    src:  "{{ easybuild_sources_dir }}/l/Lua/lua-{{ easybuild_lua_version }}.tar.bz2"
-    dest: "{{ easybuild_sources_dir }}/l/Lua/"
-    copy: no
-    mode: "{{ MODE__775_SOFT }}"
-  when: lua_install_from_source|default(false)
-- name: Compile and install Lua
-  shell: |
-         cd {{ easybuild_sources_dir }}/l/Lua/lua-{{ easybuild_lua_version }}
-         ./configure --with-static=yes --prefix={{ easybuild_software_dir }}/Lua/{{ easybuild_lua_version }} \
-         && make && make install
-  when: lua_install_from_source|default(false)
-
-#
-# Lmod.
-#
-- name: Check if Lmod is installed and if yes what version
-  #
-  # Example output:
-  # Modules based on Lua: Version 6.5.8  2016-09-03 13:41 -05:00 (CDT)
-  #    by Robert McLay mclay@tacc.utexas.edu
-  #
-  shell: "unset MODULEPATH && . ~/.modulesrc >/dev/null 2>&1 && lmod -v 2>&1 | grep -i version"
-  args:
-    executable: /bin/bash
-    warn: no
-  environment:
-    SOURCE_HPC_ENV: "True"   # Required to source our modules.bashrc in non-interactive shells.
-  changed_when: false
-  failed_when: false
-  check_mode: no
-  register: lmod_installed_version
-- name: Determine if Lmod needs to be (re)installed
-  set_fact:
-    lmod_install_from_source: true
-  when: 'lmod_installed_version|failed or (lmod_installed_version.stdout | regex_replace("^.*Version ([0-9\.]+).*$", "\\1") | version_compare(easybuild_lmod_version, operator="!="))'
-- name: Report Lmod status
-  debug:
-    msg: 'Will install Lmod from source as it is either missing or present in a different version. (Detected {{ lmod_installed_version.stdout | regex_replace("^.*Version ([0-9\.]+).*$", "\\1") }} and need {{ easybuild_lmod_version }}.)'
-  when: lmod_install_from_source|default(false)
-- name: Download Lmod
-  get_url:
-    url: "https://github.com/TACC/Lmod/archive/{{ easybuild_lmod_version }}.tar.gz"
-    dest: "{{ easybuild_sources_dir }}/l/Lmod/{{ easybuild_lmod_version }}.tar.gz"
-    checksum: 'md5:a2ea3c83f08d4175f08f84ac2a9bd508'
-    mode: "{{ MODE_0664_HARD }}"
-  when: lmod_install_from_source|default(false)
-- name: Decompress Lmod
-  unarchive:
-    src:  "{{ easybuild_sources_dir }}/l/Lmod/{{ easybuild_lmod_version }}.tar.gz"
-    dest: "{{ easybuild_sources_dir }}/l/Lmod/"
-    copy: no
-    mode: "{{ MODE__775_SOFT }}"
-  when: lmod_install_from_source|default(false)
-- name: Compile and install Lmod
-  shell: |
-         export PATH={{ easybuild_software_dir }}/Lua/{{ easybuild_lua_version }}/bin:$PATH
-         cd {{ easybuild_sources_dir }}/l/Lmod/Lmod-{{ easybuild_lmod_version }}
-         ./configure --prefix={{ easybuild_software_dir }} --with-lua-include={{ easybuild_software_dir }}/Lua/{{ easybuild_lua_version }}/include \
-                     --with-mpathSearch=YES \
-                     --with-caseIndependentSorting=YES \
-                     && make install
-  when: lmod_install_from_source|default(false)
-
-#
-# Update environment.
-#
 - name: Create global modules.bashrc with Lmod and EasyBuild environment config.
   template: src="{{ item.src }}" dest="{{ easybuild_modules_dir }}/{{ item.dest }}" mode="{{ MODE_0664_HARD }}"
   with_items:
@@ -163,61 +51,90 @@
     insertafter: EOF
     create: yes
 
+#
+# Lua.
+#
+- name: Check if Lua is installed and if yes what version.
+  #
+  # Example output:
+  # Lua 5.1.4.7-rtm  Copyright (C) 1994-2008 Lua.org, PUC-Rio
+  #
+  shell: |
+         unset MODULEPATH
+         source ~/.modulesrc >/dev/null 2>&1
+         lua -v  2>&1 | grep -i Lua | sed 's|^.*Lua \([0-9\.]*\).*$|\1|'
+  args:
+    executable: /bin/bash
+    warn: no
+  environment:
+    SOURCE_HPC_ENV: "True"   # Required to source our modules.bashrc in non-interactive shells.
+  changed_when: false
+  failed_when: false
+  check_mode: no
+  register: lua_installed_version 
+- name: Report Lua status.
+  debug:
+    #msg: 'Will install Lua from source as it is either missing or present in a different version. (Detected {{ lua_installed_version.stderr | regex_replace("^.*Lua ([0-9\.]+).*$", "\\1") }} and need {{ easybuild_lua_version }}.)'
+    msg: 'Will install Lua from source as it is either missing or present in a different version. (Detected {{ lua_installed_version.stdout }} and need {{ easybuild_lua_version }}.)'
+  when:         'lua_installed_version|failed or (lua_installed_version.stdout | version_compare(easybuild_lua_version, operator="!="))'
+  changed_when: 'lua_installed_version|failed or (lua_installed_version.stdout | version_compare(easybuild_lua_version, operator="!="))'
+  notify: 'Install_Lua_Lmod_EasyBuild_trio'
+
+#
+# Lmod.
+#
+- name: Check if Lmod is installed and if yes what version.
+  #
+  # Example output:
+  # Modules based on Lua: Version 6.5.8  2016-09-03 13:41 -05:00 (CDT)
+  #    by Robert McLay mclay@tacc.utexas.edu
+  #
+  shell: |
+         unset MODULEPATH
+         source ~/.modulesrc >/dev/null 2>&1
+         lmod -v 2>&1 | sed '/^$/d' | sed 's|^.*Version \([0-9\.]*\).*$|\1|' | head -1
+  args:
+    executable: /bin/bash
+    warn: no
+  environment:
+    SOURCE_HPC_ENV: "True"   # Required to source our modules.bashrc in non-interactive shells.
+  changed_when: false
+  failed_when: false
+  check_mode: no
+  register: lmod_installed_version
+- name: Report Lmod status.
+  debug:
+    msg: 'Will install Lmod from source as it is either missing or present in a different version. (Detected {{ lmod_installed_version.stdout }} and need {{ easybuild_lmod_version }}.)'
+  when:         'lmod_installed_version|failed or (lmod_installed_version.stdout | version_compare(easybuild_lmod_version, operator="!="))'
+  changed_when: 'lmod_installed_version|failed or (lmod_installed_version.stdout | version_compare(easybuild_lmod_version, operator="!="))'
+  notify: 'Install_Lua_Lmod_EasyBuild_trio'
 
 #
 # EasyBuild.
 #
-- name: Check if EasyBuild is installed and if yes what version
-  shell: "module load EasyBuild/{{ easybuild_eb_version }} && eb --version"
+- name: Check if EasyBuild is installed and if yes what version.
+  shell: |
+         source ~/.modulesrc >/dev/null 2>&1
+         module load EasyBuild/{{ easybuild_eb_version }}
+         eb --version 2>&1 | sed 's|^This is EasyBuild \([0-9\.]*\).*$|\1|'
   args:
     executable: /bin/bash
     warn: no
+  environment:
+    SOURCE_HPC_ENV: "True"   # Required to source our modules.bashrc in non-interactive shells.
   changed_when: false
   failed_when: false
   check_mode: no
   register: eb_installed_version
-- name: Determine if EasyBuild needs to be (re)installed
-  set_fact:
-    eb_install_from_source: true
-  when: 'eb_installed_version|failed or (eb_installed_version.stdout | regex_replace("^.*EasyBuild([0-9\.]+).*$", "\\1") | version_compare(easybuild_eb_version, operator="!="))'
-- name: Report EasyBuild status
+#- name: DEBUG EasyBuild version number.
+#  debug:
+#    msg: 'Detected {{ eb_installed_version.stdout | version_compare(easybuild_eb_version, operator="!=") }}.'
+#- debug: var=eb_installed_version
+- name: Report EasyBuild status.
   debug:
-    msg: 'Will install EasyBuild from source as it is either missing or present in a different version. (Detected {{ eb_installed_version.stdout | regex_replace("^.*EasyBuild ([0-9\.]+).*$", "\\1") }} and need {{ easybuild_eb_version }}.)'
-  when: eb_install_from_source|default(false)
-- name: Download EasyBuild bootstrap script
-  get_url:
-    url: "https://raw.githubusercontent.com/hpcugent/easybuild-framework/develop/easybuild/scripts/bootstrap_eb.py"
-    dest: "{{ easybuild_sources_dir }}/e/EasyBuild/bootstrap_eb.py"
-    mode: "{{ MODE_0664_HARD }}"
-  when: eb_install_from_source|default(false)
+    msg: 'Will bootstrap the latest EasyBuild version from source as it is either missing or present in a different version. (Detected {{ eb_installed_version.stdout }} and need {{ easybuild_eb_version }}.)'
+  when:         'eb_installed_version|failed or (eb_installed_version.stdout | version_compare(easybuild_eb_version, operator="!="))'
+  changed_when: 'eb_installed_version|failed or (eb_installed_version.stdout | version_compare(easybuild_eb_version, operator="!="))'
+  notify: 'Install_Lua_Lmod_EasyBuild_trio'
 
-#
-# Ansible doesn't run task in a login shell, so we have to source the EasyBuild config manually.
-#
-
-- name: install latest version of easybuild
-  shell: >
-         source {{ easybuild_modules_dir }}/modules.bashrc
-         && umask 0002
-         && python {{ easybuild_sources_dir }}/e/EasyBuild/bootstrap_eb.py {{ HPC_ENV_PREFIX }}
-  when: eb_install_from_source|default(false)
-- name: Check if the stable EasyBuild version is installed
-  shell: "module load EasyBuild/{{ easybuild_eb_version }} && eb --version"
-  args:
-    executable: /bin/bash
-    warn: no
-  changed_when: false
-  failed_when: false
-  check_mode: no
-  register: eb_installed_version
-- name: Determine if the stable EasyBuild version needs to be installed
-  set_fact:
-    eb_install_from_source: true
-  when: 'eb_installed_version|failed or (eb_installed_version.stdout | regex_replace("^.*EasyBuild([0-9\.]+).*$", "\\1") | version_compare(easybuild_eb_version, operator="!="))'
-- name: install stable version of easybuild
-  shell: >
-        source {{ easybuild_modules_dir }}/modules.bashrc
-        eb --software="EasyBuild",{{ easybuild_eb_version }}
-  when: eb_install_from_source|default(false)
-
-
+- meta: flush_handlers


### PR DESCRIPTION
* Updated minimal version for Ansible 2.2 -> 2.4
* Improved environment handling.
* Updated ansible-role-easybuild with additional OS deps.
* Cleanup of paths in pb_remote_env_cache_dir to make the dir layout in sync with the deployed apps.
* Refactored deployment of Lua+Lmod+EasyBuild to use a handler which will be skipped when the trio is already in place.